### PR TITLE
Fixed off-by-1 bug in get_sigsqs(after_burn_in=T)

### DIFF
--- a/bartMachine/R/bart_package_plots.R
+++ b/bartMachine/R/bart_package_plots.R
@@ -262,7 +262,7 @@ get_sigsqs = function(bart_machine, after_burn_in = T, plot_hist = F, plot_CI = 
 	num_gibbs = bart_machine$num_gibbs
 	num_trees = bart_machine$num_trees
 	
-	sigsqs_after_burnin = sigsqs[(length(sigsqs) - num_iterations_after_burn_in) : length(sigsqs)]
+	sigsqs_after_burnin = tail(sigsqs, num_iterations_after_burn_in)
 	avg_sigsqs = mean(sigsqs_after_burnin, na.rm = TRUE)
 	
 	if(plot_hist){


### PR DESCRIPTION
get_sigsqs(after_burn_in=T) was returning the sigsqs for the last burn-in forest in addition to all after burn-in forests.

Imagine that you had 250 burn-ins and 1000 after burn-ins (1250 total samples)

Before this change you'd get:

```
(length(sigsqs) - num_iterations_after_burn_in) : length(sigsqs)
```

which is equivalent to

```
(1250 - 1000) : 1250
250:1250
250, 251, ..., 1249, 1250
```

which has length (1250 - 250) + 1 = 1001.

After this change you'd get:

```
251:1250
251, 252, ... , 1249, 1250
```

which has length (1250 - 251) + 1 = 1000

which I believe is the expected behavior.

Thanks for all your work on this interesting package!
